### PR TITLE
Add mgos_i2c_{get,set}bits_reg_{w,b}()

### DIFF
--- a/include/mgos_i2c.h
+++ b/include/mgos_i2c.h
@@ -145,8 +145,10 @@ bool mgos_i2c_write_reg_n(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
 /*
  * Helper to set/get a number of bits in a register `reg` on a device at
  * address `addr`.
- * - bitoffset: 0..7 is the position at which to write `value`
- * - bitlen   : number of bits to write
+ * - bitoffset: 0..n, is the position at which to write `value`
+ *              n=7 for reg_b, n=15 for reg_w
+ * - bitlen   : 1..m, number of bits to write
+ *              m=8 for reg_b, m=16 for reg_w
  * - value    : the value to write there
  *
  * Invariants:
@@ -159,6 +161,26 @@ bool mgos_i2c_write_reg_n(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
  * will return the value of those bits in *value.
  *
  * Returns `true` in case of success, `false` otherwise.
+ *
+ * Examples (the bits set or get are between []):
+ * 1) If register was 0x00 (0b00000000)
+ *    mgos_i2c_setbits_reg_b(conn, addr, reg, 0, 1, 1);
+ *    Register will be 0x01 (0b0000000[1])
+ * 2) If register was 0xffff (0b1111111111111111)
+ *    mgos_i2c_setbits_reg_w(conn, addr, reg, 14, 2, 0);
+ *    Register will be 0x3fff (0b[00]11111111111111)
+ * 3) If register was 0xabcd (0b1010101111001101)
+ *    mgos_i2c_setbits_reg_w(conn, addr, reg, 10, 4, 5);
+ *    Register will be 0x97cd (0b10[0101]1111001101)
+ * 4) If register was 0xabcd (0b1010101111001101)
+ *    mgos_i2c_getbits_reg_w(conn, addr, reg, 0, 2, &value);
+ *    value will be 1   (0b10101011110011[01])
+ *    mgos_i2c_getbits_reg_w(conn, addr, reg, 13, 3, &value);
+ *    value will be 5   (0b[101]0101111001101)
+ *    mgos_i2c_getbits_reg_w(conn, addr, reg, 6, 5, &value);
+ *    value will be 15  (0b10101[01111]001101)
+ *    mgos_i2c_getbits_reg_w(conn, addr, reg, 5, 9, &value);
+ *    value will be 350 (0b10[101011110]01101)
  */
 bool mgos_i2c_setbits_reg_b(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
                             uint8_t bitoffset, uint8_t bitlen, uint8_t value);

--- a/include/mgos_i2c.h
+++ b/include/mgos_i2c.h
@@ -142,6 +142,33 @@ bool mgos_i2c_write_reg_w(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
 bool mgos_i2c_write_reg_n(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
                           size_t n, const uint8_t *buf);
 
+/*
+ * Helper to set/get a number of bits in a register `reg` on a device at
+ * address `addr`.
+ * - bitoffset: 0..7 is the position at which to write `value`
+ * - bitlen   : number of bits to write
+ * - value    : the value to write there
+ *
+ * Invariants:
+ * - value must fit in `bitlen` (ie value < 2^bitlen)
+ * - bitlen+bitoffset <= register size (8 for reg_b, 16 for reg_w)
+ * - bitlen cannot be 0.
+ * - *conn cannot be NULL.
+ *
+ * The `setbits` call will write the bits to the register, the `getbits` call
+ * will return the value of those bits in *value.
+ *
+ * Returns `true` in case of success, `false` otherwise.
+ */
+bool mgos_i2c_setbits_reg_b(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint8_t value);
+bool mgos_i2c_getbits_reg_b(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint8_t *value);
+bool mgos_i2c_setbits_reg_w(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint16_t value);
+bool mgos_i2c_getbits_reg_w(struct mgos_i2c *conn, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint16_t *value);
+
 /* Close i2c connection and free resources. */
 void mgos_i2c_close(struct mgos_i2c *conn);
 

--- a/src/mgos_i2c_master.c
+++ b/src/mgos_i2c_master.c
@@ -113,3 +113,91 @@ bool mgos_i2c_reset_bus(int sda_gpio, int scl_gpio) {
   HALF_DELAY();
   return true;
 }
+
+bool mgos_i2c_setbits_reg_b(struct mgos_i2c *i2c, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint8_t value) {
+  uint8_t old, new;
+
+  if (!i2c || bitoffset + bitlen > 8 || bitlen == 0) {
+    return false;
+  }
+
+  if (value > (1 << bitlen) - 1) {
+    return false;
+  }
+
+  if (!mgos_i2c_read_reg_n(i2c, addr, reg, 1, &old)) {
+    return false;
+  }
+
+  new  = old | (((1 << bitlen) - 1) << bitoffset);
+  new &= ~(((1 << bitlen) - 1) << bitoffset);
+  new |= (value) << bitoffset;
+
+  return mgos_i2c_write_reg_n(i2c, addr, reg, 1, &new);
+}
+
+bool mgos_i2c_getbits_reg_b(struct mgos_i2c *i2c, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint8_t *value) {
+  uint8_t val, mask;
+
+  if (!i2c || bitoffset + bitlen > 8 || bitlen == 0 || !value) {
+    return false;
+  }
+
+  if (!mgos_i2c_read_reg_n(i2c, addr, reg, 1, &val)) {
+    return false;
+  }
+
+  mask   = ((1 << bitlen) - 1);
+  mask <<= bitoffset;
+  val   &= mask;
+  val  >>= bitoffset;
+
+  *value = val;
+  return true;
+}
+
+bool mgos_i2c_setbits_reg_w(struct mgos_i2c *i2c, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint16_t value) {
+  uint16_t old, new;
+
+  if (!i2c || bitoffset + bitlen > 16 || bitlen == 0) {
+    return false;
+  }
+
+  if (value > (1 << bitlen) - 1) {
+    return false;
+  }
+
+  if (!mgos_i2c_read_reg_n(i2c, addr, reg, 2, (uint8_t *)&old)) {
+    return false;
+  }
+
+  new  = old | (((1 << bitlen) - 1) << bitoffset);
+  new &= ~(((1 << bitlen) - 1) << bitoffset);
+  new |= (value) << bitoffset;
+
+  return mgos_i2c_write_reg_n(i2c, addr, reg, 2, (uint8_t *)&new);
+}
+
+bool mgos_i2c_getbits_reg_w(struct mgos_i2c *i2c, uint16_t addr, uint8_t reg,
+                            uint8_t bitoffset, uint8_t bitlen, uint16_t *value) {
+  uint16_t val, mask;
+
+  if (!i2c || bitoffset + bitlen > 16 || bitlen == 0 || !value) {
+    return false;
+  }
+
+  if (!mgos_i2c_read_reg_n(i2c, addr, reg, 2, (uint8_t*) &val)) {
+    return false;
+  }
+
+  mask   = ((1 << bitlen) - 1);
+  mask <<= bitoffset;
+  val   &= mask;
+  val  >>= bitoffset;
+
+  *value = val;
+  return true;
+}


### PR DESCRIPTION
See comment for the *proof*. It's quite unorthodox to add unit tests to `mongoose-os-libs`, but I do have unit tests in my home client and happy to share them.
They test the boundary conditions:
*   bitlen=0 -> FAIL
*   bitlen=1 && bitoffset=16 -> PASS
*   bitlen=2 && bitoffset=16 -> FAIL
*   bitlen=3 && value=7 -> PASS
*   bitlen=3 && value=8 -> FAIL
*   bitoffset=17 -> FAIL

And they also test normal writing conditions thoroughly.

@mamuesp FYI
@rojer please review / merge if you like the semantics here.

