### PR TITLE
Implement linux-i2c vesion of I2C library for use in Ubuntu platform

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -83,7 +83,7 @@ conds:
         - ["i2c", "o", {title: "I2C settings"}]
         - ["i2c.enable", "b", false, {title: "Enable I2C"}]
         - ["i2c.debug", "b", false, {title: "Debug I2C bus activity"}]
-        - ["i2c.bus_no", "i", 0, {title: "Which /dev/i2c-? to use"}]
+        - ["i2c.dev_no", "i", 0, {title: "Which /dev/i2c-? to use"}]
 
 tags:
   - c

--- a/mos.yml
+++ b/mos.yml
@@ -82,6 +82,7 @@ conds:
       config_schema:
         - ["i2c", "o", {title: "I2C settings"}]
         - ["i2c.enable", "b", false, {title: "Enable I2C"}]
+        - ["i2c.debug", "b", false, {title: "Debug I2C bus activity"}]
         - ["i2c.bus_no", "i", 0, {title: "Which /dev/i2c-? to use"}]
 
 tags:

--- a/mos.yml
+++ b/mos.yml
@@ -75,6 +75,17 @@ conds:
         - ["i2c.scl_gpio", "i", -1, {title: "GPIO to use for SCL"}]
         - ["i2c1", "i2c", {title: "I2C settings"}]
 
+  - when: mos.platform == "ubuntu"
+    apply:
+      sources:
+        - src/ubuntu
+      config_schema:
+        - ["i2c", "o", {title: "I2C settings"}]
+        - ["i2c.enable", "b", false, {title: "Enable I2C"}]
+        - ["i2c.freq", "i", 100000, {title: "Clock frequency"}]
+        - ["i2c.debug", "b", false, {title: "Debug I2C bus activity"}]
+        - ["i2c.bus_no", "i", 0, {title: "Which /dev/i2c-? to use"}]
+
 tags:
   - c
   - hw

--- a/mos.yml
+++ b/mos.yml
@@ -82,8 +82,6 @@ conds:
       config_schema:
         - ["i2c", "o", {title: "I2C settings"}]
         - ["i2c.enable", "b", false, {title: "Enable I2C"}]
-        - ["i2c.freq", "i", 100000, {title: "Clock frequency"}]
-        - ["i2c.debug", "b", false, {title: "Debug I2C bus activity"}]
         - ["i2c.bus_no", "i", 0, {title: "Which /dev/i2c-? to use"}]
 
 tags:

--- a/src/mgos_i2c_master.c
+++ b/src/mgos_i2c_master.c
@@ -19,6 +19,7 @@
 
 #include "mgos_gpio.h"
 #include "mgos_hal.h"
+#include "common/cs_dbg.h"
 
 #ifndef MGOS_SYS_CONFIG_HAVE_I2C1
 #define NUM_BUSES 1

--- a/src/mgos_i2c_master.c
+++ b/src/mgos_i2c_master.c
@@ -19,7 +19,6 @@
 
 #include "mgos_gpio.h"
 #include "mgos_hal.h"
-#include "common/cs_dbg.h"
 
 #ifndef MGOS_SYS_CONFIG_HAVE_I2C1
 #define NUM_BUSES 1

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -145,7 +145,7 @@ struct mgos_i2c *mgos_i2c_create(const struct mgos_config_i2c *cfg) {
   struct mgos_i2c *c = NULL;
   int fd;
 
-  if (c == NULL) {
+  if (cfg == NULL) {
     return NULL;
   }
 

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -145,7 +145,7 @@ struct mgos_i2c *mgos_i2c_create(const struct mgos_config_i2c *cfg) {
   struct mgos_i2c *c = NULL;
   int fd;
 
-  if (c == NULLfg) {
+  if (c == NULL) {
     return NULL;
   }
 

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -67,8 +67,9 @@ bool mgos_i2c_write(struct mgos_i2c *c, uint16_t addr, const void *data, size_t 
     return false;
   }
   ret = write(c->fd, data, len);
+  if (c->cfg.debug)
+    LOG(LL_DEBUG, ("Sent %d bytes (wanted %lu) to 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
   if (ret != (int)len) {
-    LOG(LL_ERROR, ("Sent %d bytes (wanted %lu) to 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
     return false;
   }
 
@@ -106,8 +107,9 @@ bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len, bo
   }
 
   ret = read(c->fd, data, len);
+  if (c->cfg.debug)
+    LOG(LL_DEBUG, ("Received %d bytes (wanted %lu) from 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
   if (ret != (int)len) {
-    LOG(LL_ERROR, ("Received %d bytes (wanted %lu) from 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
     return false;
   }
   return true;
@@ -152,9 +154,7 @@ struct mgos_i2c *mgos_i2c_create(const struct mgos_config_i2c *cfg) {
 
   c->fd = fd;
   c->read_timeout_ms = 150;
-  if (!mgos_i2c_set_freq(c, cfg->freq)) {
-    goto out_err;
-  }
+  c->freq = MGOS_I2C_FREQ_100KHZ;
 
   LOG(LL_INFO, ("I2C%d init ok (dev: %s, freq: %d)", c->cfg.bus_no, mgos_i2c_dev_filename(c), c->freq));
 

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -89,7 +89,7 @@ bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len,
   struct timeval tv;
   int ret;
 
-  if (!c) {
+  if (c == NULL) {
     return false;
   }
 
@@ -175,7 +175,7 @@ out_err:
   if (c) {
     free(c);
   }
-  if (fd > 0) {
+  if (fd >= 0) {
     close(fd);
   }
   LOG(LL_ERROR, ("Invalid I2C settings"));
@@ -186,7 +186,7 @@ void mgos_i2c_close(struct mgos_i2c *c) {
   if (!c) {
     return;
   }
-  if (c->fd > 0) {
+  if (c->fd >= 0) {
     close(c->fd);
   }
   free(c);

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -36,7 +36,7 @@ struct mgos_i2c {
 static const char *mgos_i2c_dev_filename(struct mgos_i2c *c) {
   static char fn[256];
 
-  if (!c) {
+  if (c == NULL) {
     return "NULL";
   }
 
@@ -45,7 +45,7 @@ static const char *mgos_i2c_dev_filename(struct mgos_i2c *c) {
 }
 
 bool mgos_i2c_set_freq(struct mgos_i2c *c, int freq) {
-  if (!c) {
+  if (c == NULL) {
     return false;
   }
   if (freq != MGOS_I2C_FREQ_100KHZ) {
@@ -60,7 +60,7 @@ bool mgos_i2c_write(struct mgos_i2c *c, uint16_t addr, const void *data,
                     size_t len, bool stop) {
   int ret;
 
-  if (!c) {
+  if (c == NULL) {
     return false;
   }
 
@@ -128,14 +128,14 @@ bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len,
 }
 
 void mgos_i2c_stop(struct mgos_i2c *c) {
-  if (!c) {
+  if (c == NULL) {
     return;
   }
   LOG(LL_WARN, ("Not implemented"));
 }
 
 int mgos_i2c_get_freq(struct mgos_i2c *c) {
-  if (!c) {
+  if (c == NULL) {
     return 0;
   }
   return c->freq;
@@ -145,7 +145,7 @@ struct mgos_i2c *mgos_i2c_create(const struct mgos_config_i2c *cfg) {
   struct mgos_i2c *c = NULL;
   int fd;
 
-  if (!cfg) {
+  if (c == NULLfg) {
     return NULL;
   }
 
@@ -183,7 +183,7 @@ out_err:
 }
 
 void mgos_i2c_close(struct mgos_i2c *c) {
-  if (!c) {
+  if (c == NULL) {
     return;
   }
   if (c->fd >= 0) {

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/ioctl.h>
+#include <linux/i2c-dev.h>
+#include "mgos_i2c.h"
+#include "ubuntu_ipc.h"
+#include "common/cs_dbg.h"
+
+struct mgos_i2c {
+  struct mgos_config_i2c cfg;
+  int                    freq;
+  int                    read_timeout_ms;
+  int                    fd;
+};
+
+static const char *mgos_i2c_dev_filename(struct mgos_i2c *c) {
+  static char fn[256];
+
+  if (!c) {
+    return "NULL";
+  }
+
+  snprintf(fn, sizeof(fn) - 1, "/dev/i2c-%d", c->cfg.bus_no);
+  return (const char *)fn;
+}
+
+bool mgos_i2c_set_freq(struct mgos_i2c *c, int freq) {
+  if (!c) {
+    return false;
+  }
+  if (freq != MGOS_I2C_FREQ_100KHZ) {
+    LOG(LL_ERROR, ("This driver only supports 100KHz I2C"));
+    return false;
+  }
+  c->freq = freq;
+  return true;
+}
+
+bool mgos_i2c_write(struct mgos_i2c *c, uint16_t addr, const void *data, size_t len, bool stop) {
+  int ret;
+
+  if (!c) {
+    return false;
+  }
+
+  if (ioctl(c->fd, I2C_SLAVE, addr) < 0) {
+    LOG(LL_ERROR, ("Cannot select slave 0x%02x on I2C%d bus", addr, c->cfg.bus_no));
+    return false;
+  }
+  ret = write(c->fd, data, len);
+  if (ret != (int)len) {
+    LOG(LL_ERROR, ("Sent %d bytes (wanted %lu) to 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
+    return false;
+  }
+
+  return true;
+
+  (void)stop;
+}
+
+bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len, bool stop) {
+  fd_set         rfds;
+  struct timeval tv;
+  int            ret;
+
+  if (!c) {
+    return false;
+  }
+
+  if (ioctl(c->fd, I2C_SLAVE, addr) < 0) {
+    LOG(LL_ERROR, ("Cannot select slave 0x%02x on I2C%d bus", addr, c->cfg.bus_no));
+    return false;
+  }
+
+  FD_ZERO(&rfds);
+  FD_SET(c->fd, &rfds);
+
+  tv.tv_sec  = 0;
+  tv.tv_usec = c->read_timeout_ms * 1000;
+  ret        = select(FD_SETSIZE, &rfds, NULL, NULL, &tv);
+  if (ret < 0) {
+    LOG(LL_ERROR, ("Cannot not select(): %s", strerror(errno)));
+    return false;
+  } else if (ret == 0) {
+    LOG(LL_ERROR, ("Read timeout (%dms) from slave 0x%02x on I2C%d bus", c->read_timeout_ms, addr, c->cfg.bus_no));
+    return false;
+  }
+
+  ret = read(c->fd, data, len);
+  if (ret != (int)len) {
+    LOG(LL_ERROR, ("Received %d bytes (wanted %lu) from 0x%02x on I2C%d bus", ret, len, addr, c->cfg.bus_no));
+    return false;
+  }
+  return true;
+
+  (void)stop;
+}
+
+void mgos_i2c_stop(struct mgos_i2c *c) {
+  if (!c) {
+    return;
+  }
+  LOG(LL_WARN, ("Not implemented"));
+}
+
+int mgos_i2c_get_freq(struct mgos_i2c *c) {
+  if (!c) {
+    return 0;
+  }
+  return c->freq;
+}
+
+struct mgos_i2c *mgos_i2c_create(const struct mgos_config_i2c *cfg) {
+  struct mgos_i2c *c = NULL;
+  int fd;
+
+  if (!cfg) {
+    return NULL;
+  }
+
+  c = calloc(1, sizeof(*c));
+  if (c == NULL) {
+    return NULL;
+  }
+
+  memset(c, 0, sizeof(struct mgos_i2c));
+  memcpy(&c->cfg, cfg, sizeof(c->cfg));
+  fd = ubuntu_ipc_open(mgos_i2c_dev_filename(c), O_RDWR);
+  if (fd < 0) {
+    LOG(LL_ERROR, ("Could not open %s", mgos_i2c_dev_filename(c)));
+    goto out_err;
+  }
+
+  c->fd = fd;
+  c->read_timeout_ms = 150;
+  if (!mgos_i2c_set_freq(c, cfg->freq)) {
+    goto out_err;
+  }
+
+  LOG(LL_INFO, ("I2C%d init ok (dev: %s, freq: %d)", c->cfg.bus_no, mgos_i2c_dev_filename(c), c->freq));
+
+  return c;
+
+out_err:
+  if (c) {
+    free(c);
+  }
+  if (fd > 0) {
+    close(fd);
+  }
+  LOG(LL_ERROR, ("Invalid I2C settings"));
+  return NULL;
+}
+
+void mgos_i2c_close(struct mgos_i2c *c) {
+  if (!c) {
+    return;
+  }
+  if (c->fd > 0) {
+    close(c->fd);
+  }
+  free(c);
+}


### PR DESCRIPTION
This adds `i2c.dev_no` to mos.yml, which instructs the driver to open /dev/i2c-? as backend for I2C.
It then implements a Linux I2C version of the driver, using ioctl() to select the slave, and read/write to write to it.

Notes:
*    Linux doesn't have a call to free/reset the bus
*    Linux doesn't expose the underlying SCL/SDA pins, so bitbanging a reset is not possible.
*    Linux doesn't allow stop bit to be absent (!)
*    Linux only supports 100KHz frequency.

Basic functionality works -- reading and writing, SMBUS register read/write, and scanning.
