### PR TITLE
Fix size_t casting

### DIFF
--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -70,8 +70,8 @@ bool mgos_i2c_write(struct mgos_i2c *c, uint16_t addr, const void *data,
   }
   ret = write(c->fd, data, len);
   if (c->cfg.debug) {
-    LOG(LL_DEBUG, ("Sent %d bytes (wanted %zu) to 0x%02x on I2C bus %s", ret,
-                   len, addr, mgos_i2c_dev_filename(c)));
+    LOG(LL_DEBUG, ("Sent %d bytes (wanted %lu) to 0x%02x on I2C bus %s", ret,
+                   (unsigned long) len, addr, mgos_i2c_dev_filename(c)));
   }
   if (ret != (int) len) {
     return false;
@@ -115,8 +115,8 @@ bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len,
 
   ret = read(c->fd, data, len);
   if (c->cfg.debug) {
-    LOG(LL_DEBUG, ("Received %d bytes (wanted %zu) from 0x%02x on I2C bus %s",
-                   ret, len, addr, mgos_i2c_dev_filename(c)));
+    LOG(LL_DEBUG, ("Received %d bytes (wanted %lu) from 0x%02x on I2C bus %s",
+                   ret, (unsigned long) len, addr, mgos_i2c_dev_filename(c)));
   }
   if (ret != (int) len) {
     return false;

--- a/src/ubuntu/ubuntu_i2c_master.c
+++ b/src/ubuntu/ubuntu_i2c_master.c
@@ -70,7 +70,7 @@ bool mgos_i2c_write(struct mgos_i2c *c, uint16_t addr, const void *data,
   }
   ret = write(c->fd, data, len);
   if (c->cfg.debug) {
-    LOG(LL_DEBUG, ("Sent %d bytes (wanted %lu) to 0x%02x on I2C bus %s", ret,
+    LOG(LL_DEBUG, ("Sent %d bytes (wanted %zu) to 0x%02x on I2C bus %s", ret,
                    len, addr, mgos_i2c_dev_filename(c)));
   }
   if (ret != (int) len) {
@@ -115,7 +115,7 @@ bool mgos_i2c_read(struct mgos_i2c *c, uint16_t addr, void *data, size_t len,
 
   ret = read(c->fd, data, len);
   if (c->cfg.debug) {
-    LOG(LL_DEBUG, ("Received %d bytes (wanted %lu) from 0x%02x on I2C bus %s",
+    LOG(LL_DEBUG, ("Received %d bytes (wanted %zu) from 0x%02x on I2C bus %s",
                    ret, len, addr, mgos_i2c_dev_filename(c)));
   }
   if (ret != (int) len) {


### PR DESCRIPTION
Using %zu allows to cast size_t on 32bit and 64bit machine types.

This prepares for cross-compiled builds in and was found in:
https://github.com/cesanta/mongoose-os/issues/533